### PR TITLE
ignore missing native argument type hint

### DIFF
--- a/bin/php-insights-test
+++ b/bin/php-insights-test
@@ -3,4 +3,4 @@
 set -e
 
 DIR="$(dirname "$(readlink -f "$0")")"
-vendor/bin/phpinsights analyse --config-path=${DIR}/../configs/phpinsights.php --no-interaction -v --disable-security-check --min-quality=90 --min-architecture=100 --min-style=100 "${@}"
+vendor/bin/phpinsights analyse --config-path=${DIR}/../configs/phpinsights.php --no-interaction -v --disable-security-check --min-quality=100 --min-architecture=100 --min-style=100 "${@}"

--- a/override/SlevomatCodingStandard/Helpers/SuppressHelper.php
+++ b/override/SlevomatCodingStandard/Helpers/SuppressHelper.php
@@ -16,6 +16,7 @@ class SuppressHelper
         'SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingTraversableTypeHintSpecification',
         'SlevomatCodingStandard.TypeHints.ParameterTypeHint.UselessAnnotation',
         'SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingTraversableTypeHintSpecification',
+        'SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint',
     ];
 
     public static function isSniffSuppressed(File $phpcsFile, int $pointer, string $suppressName): bool


### PR DESCRIPTION
Until PHP allows to define argument types that aren't defined in the original method or Laravel adds native type hints to all methods it's not possible to use native type-hints for methods that are part of Laravel core classes/interfaces.
100% code quality is possible with current ruleset and CI checks without enforcing them is useless