### PR TITLE
upgrade to phpinsights v1.14 and readd StaticClosureSniff

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "illuminate/support": "^6.0 || ^7.0",
     "jasonmccreary/laravel-test-assertions": "^0.3",
     "nunomaduro/larastan": "^0.5.0",
-    "nunomaduro/phpinsights": "^1.12",
+    "nunomaduro/phpinsights": "^1.14",
     "orchestra/testbench": "^4.0 || ^5.0",
     "pdepend/pdepend": "@stable",
     "phpmd/phpmd": "^2.8",

--- a/configs/phpinsights.php
+++ b/configs/phpinsights.php
@@ -24,6 +24,7 @@ use SlevomatCodingStandard\Sniffs\Commenting\InlineDocCommentDeclarationSniff;
 use SlevomatCodingStandard\Sniffs\Commenting\UselessFunctionDocCommentSniff;
 use SlevomatCodingStandard\Sniffs\ControlStructures\DisallowEmptySniff;
 use SlevomatCodingStandard\Sniffs\ControlStructures\DisallowShortTernaryOperatorSniff;
+use SlevomatCodingStandard\Sniffs\Functions\StaticClosureSniff;
 use SlevomatCodingStandard\Sniffs\Functions\UnusedParameterSniff;
 use SlevomatCodingStandard\Sniffs\TypeHints\DeclareStrictTypesSniff;
 use SlevomatCodingStandard\Sniffs\TypeHints\DisallowArrayTypeHintSyntaxSniff;
@@ -83,7 +84,7 @@ return [
     ],
 
     'add' => [
-
+        StaticClosureSniff::class,
     ],
 
     'remove' => [


### PR DESCRIPTION
https://github.com/nunomaduro/phpinsights/blob/master/CHANGELOG.md#v1140
https://bitbucket.org/elbgoods/eventgear/pull-requests/173/fix-500-error-when-more-attributes-are-in/diff