### PR TITLE
add phpdoc order and separate rules

### DIFF
--- a/configs/.php_cs.dist
+++ b/configs/.php_cs.dist
@@ -42,6 +42,8 @@ return Config::create()
         '@PSR2' => true,
         'no_unused_imports' => true,
         'phpdoc_to_comment' => false,
+        'phpdoc_order' => true,
+        'phpdoc_separation' => true,
     ]))
     ->setLineEnding("\n")
     ->setIndent(str_repeat(' ', 4))


### PR DESCRIPTION
Der primäre usecase sind die auto-generierten doc-blocks vom ide-helper bei den models.
Aktuell bin ich immer per Hand durch um die halbwegs vernünftig zu separieren - das erledigt jetzt der CS-fixer.
Leider funktioniert `phpdoc_order` nur für `@param`, `@return` und `@throw` - sprich wenn eine neue `@property` dazu kommt muss sie einmal per Hand zu den anderen properties verschoben werden und ab dann sorgt der CS fixer dafür, dass die vernünftig getrennt und separiert werden.
Wenn jemand eine Regel, gerne auch ein externes package, findet was alle phpdoc Elemente sortiert - immer her damit.