### PR TITLE
disable PHP-MD Naming\LongClassName rule

### DIFF
--- a/configs/phpmd.xml
+++ b/configs/phpmd.xml
@@ -16,6 +16,7 @@
     <rule ref="rulesets/naming.xml">
         <exclude name="ShortVariable" />
         <exclude name="LongVariable" />
+        <exclude name="LongClassName" />
     </rule>
     <rule ref="rulesets/naming.xml/ShortVariable">
         <properties>


### PR DESCRIPTION
fixes failing tests in https://github.com/elbgoods/eventgear/pull/25