### PR TITLE
unify TooManyMethods rules to same pattern and count

### DIFF
--- a/configs/phpmd.xml
+++ b/configs/phpmd.xml
@@ -30,13 +30,21 @@
     </rule>
 
     <rule ref="rulesets/codesize.xml">
+        <exclude name="TooManyMethods" />
         <exclude name="TooManyPublicMethods" />
         <exclude name="ExcessiveClassComplexity" />
         <exclude name="CyclomaticComplexity" />
         <exclude name="NPathComplexity" />
     </rule>
+    <rule ref="rulesets/codesize.xml/TooManyMethods">
+        <properties>
+            <property name="maxmethods" value="25" />
+            <property name="ignorepattern" value="(^(set|get|is|has|scope|offset))i" />
+        </properties>
+    </rule>
     <rule ref="rulesets/codesize.xml/TooManyPublicMethods">
         <properties>
+            <property name="maxmethods" value="25" />
             <property name="ignorepattern" value="(^(set|get|is|has|scope|offset))i" />
         </properties>
     </rule>


### PR DESCRIPTION
no problem with a class containing only a bunch of public methods
https://phpmd.org/rules/codesize.html
`TooManyMethods` has a threshold of `25` methods - so `TooManyPublicMethods` should have the same